### PR TITLE
Feature/add widget

### DIFF
--- a/nightcharts.cpp
+++ b/nightcharts.cpp
@@ -462,3 +462,8 @@ void pieceNC::setPerc(float Percentage)
 {
     pPerc = Percentage;
 }
+
+int Nightcharts::pieceCount()
+{
+    return pieces.count();
+}

--- a/nightcharts.h
+++ b/nightcharts.h
@@ -62,6 +62,7 @@ public:
     int setFont(QFont f);
     int draw(QPainter *painter);
     int drawLegend(QPainter *painter);
+    int pieceCount();
     double palpha;
 
 private:

--- a/nightchartswidget.cpp
+++ b/nightchartswidget.cpp
@@ -3,23 +3,42 @@
 NightchartsWidget::NightchartsWidget(QWidget *parent) :
     QWidget(parent)
 {
+    clear();
+}
+void NightchartsWidget::setType(Nightcharts::type t)
+{
+    _chart.setType(t);
+}
+void NightchartsWidget::clear()
+{
+    _chart = Nightcharts();
+    _chart.setType(Nightcharts::Histogramm);
+    _chart.setLegendType(Nightcharts::Vertical);
+
+    _margin_left = 16;
+    _margin_top = 16;
+
 }
 
 void NightchartsWidget::paintEvent(QPaintEvent * e)
 {
     QWidget::paintEvent(e);
+    if(!_chart.pieceCount()) return ;
     QPainter painter;
     QFont font;
     painter.begin(this);
-    Nightcharts PieChart;
-    PieChart.setType(Nightcharts::Dpie);//{Histogramm,Pie,DPie};
-    PieChart.setLegendType(Nightcharts::Round);//{Round,Vertical}
-    PieChart.setCords(100,100,this->width()/3,this->height()/3);
-    PieChart.addPiece("Item1",QColor(200,10,50),34);
-    PieChart.addPiece("Item2",Qt::green,27);
-    PieChart.addPiece("Item3",Qt::cyan,14);
-    PieChart.addPiece("Item4",Qt::yellow,7);
-    PieChart.addPiece("Item5",Qt::blue,4);
-    PieChart.draw(&painter);
-    PieChart.drawLegend(&painter);
+    int w = (this->width() - _margin_left - 150);
+    int h = (this->height() - _margin_top - 100);
+    int size = (w<h)?w:h;
+    _chart.setCords(_margin_left, _margin_top,size, size);
+
+
+    _chart.draw(&painter);
+    _chart.drawLegend(&painter);
+    //painter.end();
+}
+
+void NightchartsWidget::addItem(QString name, QColor color, float value)
+{
+    _chart.addPiece(name,color,value);
 }

--- a/nightchartswidget.cpp
+++ b/nightchartswidget.cpp
@@ -1,0 +1,25 @@
+#include "nightchartswidget.h"
+#include "nightcharts.h"
+NightchartsWidget::NightchartsWidget(QWidget *parent) :
+    QWidget(parent)
+{
+}
+
+void NightchartsWidget::paintEvent(QPaintEvent * e)
+{
+    QWidget::paintEvent(e);
+    QPainter painter;
+    QFont font;
+    painter.begin(this);
+    Nightcharts PieChart;
+    PieChart.setType(Nightcharts::Dpie);//{Histogramm,Pie,DPie};
+    PieChart.setLegendType(Nightcharts::Round);//{Round,Vertical}
+    PieChart.setCords(100,100,this->width()/3,this->height()/3);
+    PieChart.addPiece("Item1",QColor(200,10,50),34);
+    PieChart.addPiece("Item2",Qt::green,27);
+    PieChart.addPiece("Item3",Qt::cyan,14);
+    PieChart.addPiece("Item4",Qt::yellow,7);
+    PieChart.addPiece("Item5",Qt::blue,4);
+    PieChart.draw(&painter);
+    PieChart.drawLegend(&painter);
+}

--- a/nightchartswidget.h
+++ b/nightchartswidget.h
@@ -1,0 +1,18 @@
+#ifndef NIGHTCHARTSWIDGET_H
+#define NIGHTCHARTSWIDGET_H
+
+#include <QWidget>
+#include <QPaintEvent>
+
+class NightchartsWidget : public QWidget
+{
+    Q_OBJECT
+public:
+    explicit NightchartsWidget(QWidget *parent = 0);
+
+protected:
+    virtual void paintEvent(QPaintEvent * e);
+
+};
+
+#endif // NIGHTCHARTSWIDGET_H

--- a/nightchartswidget.h
+++ b/nightchartswidget.h
@@ -3,15 +3,21 @@
 
 #include <QWidget>
 #include <QPaintEvent>
-
+#include "nightcharts.h"
 class NightchartsWidget : public QWidget
 {
     Q_OBJECT
 public:
     explicit NightchartsWidget(QWidget *parent = 0);
-
+    void addItem(QString name, QColor color, float value);
+    void setType(Nightcharts::type type);
+    void clear();
 protected:
     virtual void paintEvent(QPaintEvent * e);
+private:
+    Nightcharts _chart;
+    int _margin_left;
+    int _margin_top;
 
 };
 


### PR DESCRIPTION
I've created a "chart widget" which now support a (sub)set of configurations proxied to nightcharts.

This makes nightcharts easily-usable in standard rapid development mode:
- create widget in designer
- promote to NightchartWidget
- configure in code
- It's painting

For example,

```
QNightchartsWidget widget;
widget.setType(NightCharts::Pie);
widget.addItem("red",Qt::red, 33);
widget.addItem("blue",Qt::blue, 64);
widget.show();
```

no need to worry about paint events reimplementing etc.
